### PR TITLE
Make send action button title customizable 

### DIFF
--- a/internal_packages/composer/lib/send-action-button.jsx
+++ b/internal_packages/composer/lib/send-action-button.jsx
@@ -116,19 +116,19 @@ export default class SendActionButton extends React.Component {
     return {preferred, rest};
   }
 
-  _contentForAction = ({iconUrl}) => {
-    let plusHTML = "";
-    let additionalImg = false;
+  _contentForAction = ({buttonTitle, title, iconUrl}) => {
+    let additionalImg = null;
+
+    const actionTitle = buttonTitle ? buttonTitle : title;
 
     if (iconUrl) {
-      plusHTML = (<span>&nbsp;+&nbsp;</span>);
       additionalImg = (<RetinaImg url={iconUrl} mode={RetinaImg.Mode.ContentIsMask} />);
     }
 
     return (
       <span>
         <RetinaImg name="icon-composer-send.png" mode={RetinaImg.Mode.ContentIsMask} />
-        <span className="text">Send{plusHTML}</span>{additionalImg}
+        <span className="text">{actionTitle}</span>{additionalImg}
       </span>
     );
   }

--- a/internal_packages/composer/lib/send-action-button.jsx
+++ b/internal_packages/composer/lib/send-action-button.jsx
@@ -119,7 +119,7 @@ export default class SendActionButton extends React.Component {
   _contentForAction = ({buttonTitle, title, iconUrl}) => {
     let additionalImg = null;
 
-    const actionTitle = buttonTitle ? buttonTitle : title;
+    const actionTitle = buttonTitle || title;
 
     if (iconUrl) {
       additionalImg = (

--- a/internal_packages/composer/lib/send-action-button.jsx
+++ b/internal_packages/composer/lib/send-action-button.jsx
@@ -122,7 +122,12 @@ export default class SendActionButton extends React.Component {
     const actionTitle = buttonTitle ? buttonTitle : title;
 
     if (iconUrl) {
-      additionalImg = (<RetinaImg url={iconUrl} mode={RetinaImg.Mode.ContentIsMask} />);
+      additionalImg = (
+        <span className="additional">
+          &nbsp;
+          <RetinaImg url={iconUrl} mode={RetinaImg.Mode.ContentIsMask} />
+        </span>
+      );
     }
 
     return (

--- a/internal_packages/send-and-archive/lib/send-and-archive-extension.cjsx
+++ b/internal_packages/send-and-archive/lib/send-and-archive-extension.cjsx
@@ -13,6 +13,7 @@ class SendAndArchiveExtension extends ComposerExtension
     if draft.threadId
       return {
         title: "Send and Archive"
+        buttonTitle: "Send + "
         iconUrl: "nylas://send-and-archive/images/composer-archive@2x.png"
         onSend: @_sendAndArchive
       }

--- a/internal_packages/send-and-archive/lib/send-and-archive-extension.cjsx
+++ b/internal_packages/send-and-archive/lib/send-and-archive-extension.cjsx
@@ -13,7 +13,7 @@ class SendAndArchiveExtension extends ComposerExtension
     if draft.threadId
       return {
         title: "Send and Archive"
-        buttonTitle: "Send + "
+        buttonTitle: "Send +"
         iconUrl: "nylas://send-and-archive/images/composer-archive@2x.png"
         onSend: @_sendAndArchive
       }

--- a/src/extensions/composer-extension.coffee
+++ b/src/extensions/composer-extension.coffee
@@ -55,13 +55,18 @@ class ComposerExtension extends ContenteditableExtension
     ## TODO FIXME: The preferences does not yet know how to dynamically
     # pick these up. For now they are hard-coded.
 
+    - `buttonTitle`: The text that is displayed in the send button. Can be
+    used in combination with an icon by setting it to "Send + ", like what
+    is done in the SendAndArchiveExtension. When not set the `title` will
+    be used instead.
+
     - `onSend`: Callback for when your option is clicked as the primary
     action. The function will be passed `{draft}` as its only argument.
     It does not need to return anything. It may be asynchronous and likely
     queue Tasks.
 
     - `iconUrl`: A custom icon to be placed in the Send button. SendAction
-    extensions have the form "Send + {ICON}"
+    extensions have the form "{TITLE} {ICON}"
   ###
   @sendActionConfig: ({draft}) ->
 


### PR DESCRIPTION
Currently the Send button always is "Send" or "Send + {ICON}". 

But when a ComposerExtension doesn't have an icon, or the icon is not descriptive enough for the action, there's no way of making clear what the send action is. 

Also, even though the documentation states: 

> It is used in the hover title text of your  option in the dropdown menu.

It is not, so maybe this title attribute should be added. Or this sentence should be removed.
