### PR TITLE
Fix broken image url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Nylas Mail - the open-source, extensible mail client
-![N1 Screenshot](https://nylas.com/static/img/home/screenshot-hero-mac@2x.png)
+![N1 Screenshot](https://nylas.com/static/img/nylas-mail/hero_graphic_mac@2x.png)
 
   **Nylas Mail is an open-source mail client built on the modern web with [Electron](https://github.com/atom/electron), [React](https://facebook.github.io/react/), and [Flux](https://facebook.github.io/flux/).** It is designed to be extensible, so it's easy to create new experiences and workflows around email. Want to learn more? Check out the [full documentation](https://nylas.github.io/nylas-mail/).
 


### PR DESCRIPTION
Seems like the website structure is changed entirely causing the url for the image in README.md to be broken.