### PR TITLE
Bump node-keytar to latest release.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
+    - sourceline: 'ppa:versable/elementary-community-ppa'
     packages:
     - build-essential
     - clang
@@ -17,7 +18,8 @@ addons:
     - libxext-dev
     - libxtst-dev
     - libxkbfile-dev
-
+    - libsecret-1-dev
+    
 branches:
   only:
   - patch-1
@@ -43,9 +45,6 @@ before_install:
 # - tar xvf packages/client-private-plugins/encrypted_certificates/travis/travis-files.tar
 #   --directory=packages/client-app/build/resources/;
 # - source packages/client-app/build/resources/certs/mac/set_unix_env.sh;
-- add-apt-repository ppa:versable/elementary-community-ppa -y
-- apt-get update -q
-- apt-get install libsecret-1-dev -y
 
 install:
 - git clone https://github.com/creationix/nvm.git /tmp/.nvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
     - fakeroot
     - g++-4.8
     - git
-    - libgnome-keyring-dev
+    - libsecret
     - xvfb
     - rpm
     - libxext-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
     - fakeroot
     - g++-4.8
     - git
-    - libsecret
+    - libsecret-1-dev
     - xvfb
     - rpm
     - libxext-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ addons:
     - fakeroot
     - g++-4.8
     - git
-    - libsecret-1-dev
     - xvfb
     - rpm
     - libxext-dev
@@ -43,6 +42,9 @@ before_install:
 - tar xvf packages/client-private-plugins/encrypted_certificates/travis/travis-files.tar
   --directory=packages/client-app/build/resources/;
 - source packages/client-app/build/resources/certs/mac/set_unix_env.sh;
+- sudo add-apt-repository ppa:versable/elementary-community-ppa -y
+- sudo apt-get update -q
+- sudo apt-get install libsecret-1-dev -y
 
 install:
 - git clone https://github.com/creationix/nvm.git /tmp/.nvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ addons:
 
 branches:
   only:
+  - patch-1
   - master
   - /ci-.*/
   - /stable.*/
@@ -42,9 +43,9 @@ before_install:
 - tar xvf packages/client-private-plugins/encrypted_certificates/travis/travis-files.tar
   --directory=packages/client-app/build/resources/;
 - source packages/client-app/build/resources/certs/mac/set_unix_env.sh;
-- sudo add-apt-repository ppa:versable/elementary-community-ppa -y
-- sudo apt-get update -q
-- sudo apt-get install libsecret-1-dev -y
+- add-apt-repository ppa:versable/elementary-community-ppa -y
+- apt-get update -q
+- apt-get install libsecret-1-dev -y
 
 install:
 - git clone https://github.com/creationix/nvm.git /tmp/.nvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,19 +30,19 @@ matrix:
   - os: linux
     env: NODE_VERSION=6.9 CC=gcc-4.8 CXX=g++-4.8 DEBUG="electron-packager:*" INSTALL_TARGET=client
   - os: osx
-    env: NODE_VERSION=6.9 CC=clang CXX=clang++ SIGN_BUILD=true DEBUG="electron-packager:*" INSTALL_TARGET=client
+    env: NODE_VERSION=6.9 CC=clang CXX=clang++ SIGN_BUILD=false DEBUG="electron-packager:*" INSTALL_TARGET=client
 
 before_install:
-- openssl aes-256-cbc
-  -K $encrypted_faf2708e46e2_key
-  -iv $encrypted_faf2708e46e2_iv
-  -in packages/client-private-plugins/encrypted_certificates/travis/travis-files.tar.enc
-  -out packages/client-private-plugins/encrypted_certificates/travis/travis-files.tar
-  -d;
-- mkdir packages/client-app/build/resources/certs;
-- tar xvf packages/client-private-plugins/encrypted_certificates/travis/travis-files.tar
-  --directory=packages/client-app/build/resources/;
-- source packages/client-app/build/resources/certs/mac/set_unix_env.sh;
+# - openssl aes-256-cbc
+#   -K $encrypted_faf2708e46e2_key
+#   -iv $encrypted_faf2708e46e2_iv
+#   -in packages/client-private-plugins/encrypted_certificates/travis/travis-files.tar.enc
+#   -out packages/client-private-plugins/encrypted_certificates/travis/travis-files.tar
+#   -d;
+# - mkdir packages/client-app/build/resources/certs;
+# - tar xvf packages/client-private-plugins/encrypted_certificates/travis/travis-files.tar
+#   --directory=packages/client-app/build/resources/;
+# - source packages/client-app/build/resources/certs/mac/set_unix_env.sh;
 - add-apt-repository ppa:versable/elementary-community-ppa -y
 - apt-get update -q
 - apt-get install libsecret-1-dev -y

--- a/packages/client-app/.travis.yml
+++ b/packages/client-app/.travis.yml
@@ -12,7 +12,7 @@ addons:
     - fakeroot
     - g++-4.8
     - git
-    - libgnome-keyring-dev
+    - libsecret
     - xvfb
     - rpm
     - libxext-dev

--- a/packages/client-app/.travis.yml
+++ b/packages/client-app/.travis.yml
@@ -6,6 +6,7 @@ addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
+    - sourceline: 'ppa:versable/elementary-community-ppa'
     packages:
     - build-essential
     - clang
@@ -17,7 +18,7 @@ addons:
     - libxext-dev
     - libxtst-dev
     - libxkbfile-dev
-
+    - libsecret-1-dev
 branches:
   only:
   - master
@@ -43,9 +44,6 @@ before_script:
   export DISPLAY=:99.0;
   sh -e /etc/init.d/xvfb start;
   fi
-- add-apt-repository ppa:versable/elementary-community-ppa -y
-- apt-get update -q
-- apt-get install libsecret-1-dev -y
 
 script:
 - npm install && npm test

--- a/packages/client-app/.travis.yml
+++ b/packages/client-app/.travis.yml
@@ -12,7 +12,6 @@ addons:
     - fakeroot
     - g++-4.8
     - git
-    - libsecret-1-dev
     - xvfb
     - rpm
     - libxext-dev
@@ -43,6 +42,9 @@ before_script:
   export DISPLAY=:99.0;
   sh -e /etc/init.d/xvfb start;
   fi
+- sudo add-apt-repository ppa:versable/elementary-community-ppa -y
+- sudo apt-get update -q
+- sudo apt-get install libsecret-1-dev -y
 
 script:
 - npm install && npm test

--- a/packages/client-app/.travis.yml
+++ b/packages/client-app/.travis.yml
@@ -12,7 +12,7 @@ addons:
     - fakeroot
     - g++-4.8
     - git
-    - libsecret
+    - libsecret-1-dev
     - xvfb
     - rpm
     - libxext-dev

--- a/packages/client-app/.travis.yml
+++ b/packages/client-app/.travis.yml
@@ -21,6 +21,7 @@ addons:
 branches:
   only:
   - master
+  - patch-1
   - /ci-.*/
   - /stable.*/
 
@@ -42,9 +43,9 @@ before_script:
   export DISPLAY=:99.0;
   sh -e /etc/init.d/xvfb start;
   fi
-- sudo add-apt-repository ppa:versable/elementary-community-ppa -y
-- sudo apt-get update -q
-- sudo apt-get install libsecret-1-dev -y
+- add-apt-repository ppa:versable/elementary-community-ppa -y
+- apt-get update -q
+- apt-get install libsecret-1-dev -y
 
 script:
 - npm install && npm test

--- a/packages/client-app/build/resources/linux/redhat/nylas.spec.in
+++ b/packages/client-app/build/resources/linux/redhat/nylas.spec.in
@@ -6,7 +6,7 @@ License:        GPLv3
 URL:            https://github.com/nylas/nylas-mail
 AutoReqProv:    no # Avoid libchromiumcontent.so missing dependency
 
-requires:       libgnome-keyring
+requires:       libsecret
 
 %description
 <%= description %>

--- a/packages/client-app/package.json
+++ b/packages/client-app/package.json
@@ -63,7 +63,7 @@
     "jsx-transform": "^2.3.0",
     "juice": "^1.4",
     "kbpgp": "^2.0.52",
-    "keytar": "3.0.0",
+    "keytar": "4.0.2",
     "less-cache": "0.21",
     "lru-cache": "^4.0.1",
     "marked": "^0.3",


### PR DESCRIPTION
libsecret has been used instead of gnome-keyring in node-keytar [since version 4.0.0](https://github.com/atom/node-keytar/commit/9d6821d8c57ae4744c07bdc10ea2910b86d15866). Moving to libsecret would be much better for users who are not using gnome, right now it means running an extra keyring.