### PR TITLE
Resolve -b option collision

### DIFF
--- a/packages/client-app/src/browser/main.js
+++ b/packages/client-app/src/browser/main.js
@@ -62,7 +62,7 @@ const declareOptions = (argv) => {
   const options = optimist(argv);
   options.usage("Nylas Mail v" + (app.getVersion()) + "\n\nUsage: nylas-mail [options]\n\nRun Nylas Mail: The open source extensible email client\n\n`nylas-mail --dev` to start the client in dev mode.\n\n`n1 --test` to run unit tests.");
   options.alias('d', 'dev').boolean('d').describe('d', 'Run in development mode.');
-  options.alias('b', 'benchmark').boolean('b').describe('b', 'Run in benchmark mode.');
+  options.boolean('benchmark').describe('benchmark', 'Run in benchmark mode.');
   options.alias('t', 'test').boolean('t').describe('t', 'Run the specified specs and exit with error code on failures.');
   options.boolean('safe').describe('safe', 'Do not load packages from ~/.nylas-mail/packages or ~/.nylas/dev/packages.');
   options.alias('h', 'help').boolean('h').describe('h', 'Print this usage message.');


### PR DESCRIPTION
Removed -b alias for --benchmark option which collides with --background option.
See #3464, #3519 