### PR TITLE
Fixes #3108 - Elementary Loki

### DIFF
--- a/packages/client-app/build/resources/linux/debian/postinst
+++ b/packages/client-app/build/resources/linux/debian/postinst
@@ -24,7 +24,7 @@ case "$1" in
 
         DISTRO=`lsb_release -s -i`
 
-        if [ "$DISTRO" = "Ubuntu" ] || [ "$DISTRO" = "elementary OS" ] || [ "$DISTRO" = "LinuxMint" ] ; then
+        if [ "$DISTRO" = "Ubuntu" ] || [ "$DISTRO" = "elementary OS" ] || [ "$DISTRO" = "elementary" ] || [ "$DISTRO" = "LinuxMint" ] ; then
           DISTS=$UBUNTU_CODENAMES
           DISTRO="ubuntu"
         elif [ "$DISTRO" = "Debian" ]; then


### PR DESCRIPTION
Elementary OS changed their release name when they released the "Loki" version of their OS. This change prevents Nylas from "installing" its repository for Loki. For versions previous to Loki, running `lsb_release -s -i` would return 

> elementary OS

In Loki, running `lsb_release -s -i` now returns

> elementary

This PR allows for both versions. Note I thought a simple "or" would be more efficient than a regex, and seems like a better choice than `"elementary"*`

See:
#3108
#3155
