### PR TITLE
Correctly parse multiple CCs/BCCs in mailto links

### DIFF
--- a/packages/client-app/spec/stores/contact-store-spec.coffee
+++ b/packages/client-app/spec/stores/contact-store-spec.coffee
@@ -151,6 +151,10 @@ xdescribe "ContactStore", ->
         new Contact(name: "Evan Morikawa", email: "evan@nylas.com")
         new Contact(name: "Ben", email: "ben@nylas.com")
       ]
+      "Evan Morikawa <evan@nylas.com>; Ben <ben@nylas.com>": [
+        new Contact(name: "Evan Morikawa", email: "evan@nylas.com")
+        new Contact(name: "Ben", email: "ben@nylas.com")
+      ]
       "mark@nylas.com\nGleb (gleb@nylas.com)\rEvan Morikawa <evan@nylas.com>, spang (Christine Spang) <noreply+phabricator@nilas.com>": [
         new Contact(name: "", email: "mark@nylas.com")
         new Contact(name: "Gleb", email: "gleb@nylas.com")

--- a/packages/client-app/spec/stores/draft-factory-spec.es6
+++ b/packages/client-app/spec/stores/draft-factory-spec.es6
@@ -623,9 +623,11 @@ describe('DraftFactory', function draftFactory() {
         'mailto:?subject=%52z2a', // passes uriDecode
         'mailto:?subject=Martha Stewart',
         'mailto:?subject=Martha Stewart&cc=cc@nylas.com',
+        'mailto:?subject=Martha Stewart&cc=cc@nylas.com;bengotow@gmail.com',
         'mailto:bengotow@gmail.com&subject=Martha Stewart&cc=cc@nylas.com',
         'mailto:bengotow@gmail.com?subject=Martha%20Stewart&cc=cc@nylas.com&bcc=bcc@nylas.com',
         'mailto:bengotow@gmail.com?subject=Martha%20Stewart&cc=cc@nylas.com&bcc=Ben <bcc@nylas.com>',
+        'mailto:bengotow@gmail.com?subject=Martha%20Stewart&cc=cc@nylas.com&bcc=Ben <bcc@nylas.com>;Shawn <shawn@nylas.com>',
         'mailto:Ben Gotow <bengotow@gmail.com>,Shawn <shawn@nylas.com>?subject=Yes this is really valid',
         'mailto:Ben%20Gotow%20<bengotow@gmail.com>,Shawn%20<shawn@nylas.com>?subject=Yes%20this%20is%20really%20valid',
         'mailto:Reply <d+AORGpRdj0KXKUPBE1LoI0a30F10Ahj3wu3olS-aDk5_7K5Wu6WqqqG8t1HxxhlZ4KEEw3WmrSdtobgUq57SkwsYAH6tG57IrNqcQR0K6XaqLM2nGNZ22D2k@docs.google.com>?subject=Nilas%20Message%20to%20Customers',
@@ -658,6 +660,13 @@ describe('DraftFactory', function draftFactory() {
             subject: 'Martha Stewart'}
         ),
         new Message(
+          {cc: [
+            new Contact({name: 'cc@nylas.com', email: 'cc@nylas.com'}),
+            new Contact({name: 'bengotow@gmail.com', email: 'bengotow@gmail.com'}),
+          ],
+            subject: 'Martha Stewart'}
+        ),
+        new Message(
           {to: [new Contact({name: 'bengotow@gmail.com', email: 'bengotow@gmail.com'})],
             cc: [new Contact({name: 'cc@nylas.com', email: 'cc@nylas.com'})],
             subject: 'Martha Stewart'}
@@ -672,6 +681,15 @@ describe('DraftFactory', function draftFactory() {
           {to: [new Contact({name: 'bengotow@gmail.com', email: 'bengotow@gmail.com'})],
             cc: [new Contact({name: 'cc@nylas.com', email: 'cc@nylas.com'})],
             bcc: [new Contact({name: 'Ben', email: 'bcc@nylas.com'})],
+            subject: 'Martha Stewart'}
+        ),
+        new Message(
+          {to: [new Contact({name: 'bengotow@gmail.com', email: 'bengotow@gmail.com'})],
+            cc: [new Contact({name: 'cc@nylas.com', email: 'cc@nylas.com'})],
+            bcc: [
+              new Contact({name: 'Ben', email: 'bcc@nylas.com'}),
+              new Contact({name: 'Shawn', email: 'shawn@nylas.com'}),
+            ],
             subject: 'Martha Stewart'}
         ),
         new Message(

--- a/packages/client-app/src/flux/stores/contact-store.coffee
+++ b/packages/client-app/src/flux/stores/contact-store.coffee
@@ -112,7 +112,7 @@ class ContactStore extends NylasStore
 
       if hasLeadingParen and hasTrailingParen
         nameStart = lastMatchEnd
-        for char in [',', '\n', '\r']
+        for char in [',', ';', '\n', '\r']
           i = contactString.lastIndexOf(char, match.index)
           nameStart = i+1 if i+1 > nameStart
         name = contactString.substr(nameStart, match.index - 1 - nameStart).trim()

--- a/packages/client-app/src/regexp-utils.coffee
+++ b/packages/client-app/src/regexp-utils.coffee
@@ -16,7 +16,7 @@ RegExpUtils =
   # See http://tools.ietf.org/html/rfc5322#section-3.4 and
   # https://tools.ietf.org/html/rfc6531 and
   # https://en.wikipedia.org/wiki/Email_address#Local_part
-  emailRegex: -> new RegExp("([a-z.A-Z#{UnicodeEmailChars}0-9!#$%&\\'*+\\-/=?^_`{|}~;]+@[A-Za-z#{UnicodeEmailChars}0-9.-]+\\.[A-Za-z]{2,63})", 'g')
+  emailRegex: -> new RegExp("([a-z.A-Z#{UnicodeEmailChars}0-9!#$%&\\'*+\\-/=?^_`{|}~]+@[A-Za-z#{UnicodeEmailChars}0-9.-]+\\.[A-Za-z]{2,63})", 'g')
 
   # http://stackoverflow.com/questions/16631571/javascript-regular-expression-detect-all-the-phone-number-from-the-page-source
   # http://www.regexpal.com/?fam=94521


### PR DESCRIPTION
Fixing #3635.

- Removed semicolon from the valid email check in `regexp-utils`.
- Added semicolon to the list of email separators, in `ContactStore.parseContactsInString()`
- Added test cases in `parseContactsInString()`, and also the `DraftFactory` (where the mailto click is handled & a new/draft email is created).