### PR TITLE
[client-app] Replace smtp/imap port dropdown with input field

### DIFF
--- a/packages/client-app/internal_packages/onboarding/lib/page-account-settings-imap.jsx
+++ b/packages/client-app/internal_packages/onboarding/lib/page-account-settings-imap.jsx
@@ -56,52 +56,6 @@ class AccountIMAPSettingsForm extends React.Component {
     this.props.onConnect();
   }
 
-  renderPortDropdown(protocol) {
-    if (!["imap", "smtp"].includes(protocol)) {
-      throw new Error(`Can't render port dropdown for protocol '${protocol}'`);
-    }
-    const {accountInfo, submitting, onFieldKeyPress, onFieldChange} = this.props;
-
-    if (protocol === "imap") {
-      return (
-        <span>
-          <label htmlFor="imap_port">Port:</label>
-          <select
-            id="imap_port"
-            tabIndex={0}
-            value={accountInfo.imap_port}
-            disabled={submitting}
-            onKeyPress={onFieldKeyPress}
-            onChange={onFieldChange}
-          >
-            <option value="143" key="143">143</option>
-            <option value="993" key="993">993</option>
-          </select>
-        </span>
-      )
-    }
-    if (protocol === "smtp") {
-      return (
-        <span>
-          <label htmlFor="smtp_port">Port:</label>
-          <select
-            id="smtp_port"
-            tabIndex={0}
-            value={accountInfo.smtp_port}
-            disabled={submitting}
-            onKeyPress={onFieldKeyPress}
-            onChange={onFieldChange}
-          >
-            <option value="25" key="25">25</option>
-            <option value="465" key="465">465</option>
-            <option value="587" key="587">587</option>
-          </select>
-        </span>
-      )
-    }
-    return "";
-  }
-
   renderSecurityDropdown(protocol) {
     const {accountInfo, submitting, onFieldKeyPress, onFieldChange} = this.props;
 
@@ -142,7 +96,7 @@ class AccountIMAPSettingsForm extends React.Component {
       <div>
         <FormField field={`${type}_host`} title={"Server"} {...this.props} />
         <div style={{textAlign: 'left'}}>
-          {this.renderPortDropdown(type)}
+          <FormField field={`${type}_port`} title={"Port"} {...this.props} />
           {this.renderSecurityDropdown(type)}
         </div>
         <FormField field={`${type}_username`} title={"Username"} {...this.props} />


### PR DESCRIPTION
Issue #3424 

I like the app, but I can't connect my own e-mail from my hosting provider, which uses '2525' as port for SMTP. I can't even write this language :D but thought it couldn't be so hard to replace the dropdowns with fixed values. Seems to be a feature request for a while but nobody is doing anything. 

Please add comments if I need to change anything, because, once again, I can't write this language.

