### PR TITLE
[pref] Fix CSS textarea issue whereby the signature box was too small…

### DIFF
--- a/packages/client-app/internal_packages/composer-signature/styles/composer-signature.less
+++ b/packages/client-app/internal_packages/composer-signature/styles/composer-signature.less
@@ -87,6 +87,8 @@
       flex: 1;
       font-family: monospace;
       font-size: 0.9em;
+      width: 100%;
+      height: 100%;
     }
 
     .contenteditable {


### PR DESCRIPTION
… when editing raw HTML.

Before:
![image](https://user-images.githubusercontent.com/115112/31666236-70b53fba-b343-11e7-9517-230eacf4f294.png)

After:
![image](https://user-images.githubusercontent.com/115112/31666297-997ba02e-b343-11e7-9ed3-ee84f8c4bf99.png)
