### PR TITLE
fix(sec): upgrade rsa to 4.7

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -8,5 +8,5 @@ pyasn1-modules==0.0.8
 pyparsing==2.2.0
 python-dateutil==2.6.0
 requests==2.13.0
-rsa==3.4.2
+rsa==4.7
 six==1.10.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in rsa 3.4.2
- [CVE-2020-25658](https://www.oscs1024.com/hd/CVE-2020-25658)


### What did I do？
Upgrade rsa from 3.4.2 to 4.7 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS