### PR TITLE
fix(sec): upgrade httplib2 to 0.19.0

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,6 +1,6 @@
 appdirs==1.4.3
 gspread==0.6.2
-httplib2==0.10.3
+httplib2==0.19.0
 oauth2client==4.0.0
 packaging==16.8
 pyasn1==0.2.3


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in httplib2 0.10.3
- [CVE-2021-21240](https://www.oscs1024.com/hd/CVE-2021-21240)


### What did I do？
Upgrade httplib2 from 0.10.3 to 0.19.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS